### PR TITLE
Corrected Colab Badge URL

### DIFF
--- a/LASER_FUNSD_Training.ipynb
+++ b/LASER_FUNSD_Training.ipynb
@@ -19,7 +19,7 @@
     {
       "cell_type": "markdown",
       "source": [
-        "<a target=\"_blank\" href=\"https://colab.research.google.com/github/https://colab.research.google.com/drive/1hlkvpGma6uA_116lzDTpJeXF0ashLC6H?usp=sharing\">\n",
+        "<a target=\"_blank\" href=\"https://colab.research.google.com/drive/1hlkvpGma6uA_116lzDTpJeXF0ashLC6H?usp=sharing\">\n",
         "  <img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/>\n",
         "</a>"
       ],

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-<a target="_blank" href="https://colab.research.google.com/github/https://colab.research.google.com/drive/1hlkvpGma6uA_116lzDTpJeXF0ashLC6H?usp=sharing">
+<a target="_blank" href="https://colab.research.google.com/drive/1hlkvpGma6uA_116lzDTpJeXF0ashLC6H?usp=sharing">
   <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/>
 </a>
 


### PR DESCRIPTION
I accidently placed wrong URL in Colab Badge redirect link, I've corrected it now.